### PR TITLE
clusters CLAB, KLAB or KLAB2 are removed from users create product menu

### DIFF
--- a/src/components/common/Constants.js
+++ b/src/components/common/Constants.js
@@ -308,6 +308,24 @@ const clusterNames = [
   }
 ];
 
+const clusterNamesUserCreate = [
+  {
+    id: 3,
+    name: "SILVER",
+    humanFriendlyName: "Silver Kamloops"
+  },
+  {
+    id: 4,
+    name: "GOLD",
+    humanFriendlyName: "Gold Kamloops"
+  },
+  {
+    id: 7,
+    name: "EMERALD",
+    humanFriendlyName: "Emerald Hosting Tier"
+  }
+];
+
 const defaultCpuOptionsLookup = {
   CPU_REQUEST_0_5_LIMIT_1_5: "0.5 CPU Request, 1.5 CPU Limit",
   CPU_REQUEST_1_LIMIT_2: "1 CPU Request, 2 CPU Limit",
@@ -377,6 +395,7 @@ export {
   defaultMemoryOptions,
   defaultStorageOptions,
   clusterNames,
+  clusterNamesUserCreate,
   defaultCpuOptionsLookup,
   defaultMemoryOptionsLookup,
   defaultStorageOptionsLookup

--- a/src/components/forms/ClusterInput.js
+++ b/src/components/forms/ClusterInput.js
@@ -16,7 +16,6 @@ export default function ClusterInput({ formik, isDisabled }) {
   const isAdmin = useContext(AdminContext);
   const clusterNamesInput = isAdmin.admin ? clusterNames : clusterNamesUserCreate;
 
-console.log(isAdmin.admin)
   return (
     <Box
       sx={{

--- a/src/components/forms/ClusterInput.js
+++ b/src/components/forms/ClusterInput.js
@@ -1,16 +1,22 @@
-import React from "react";
+import React, { useContext } from "react";
 import Box from "@mui/material/Box";
 import InputLabel from "@mui/material/InputLabel";
 import MenuItem from "@mui/material/MenuItem";
 import FormControl from "@mui/material/FormControl";
 import Select from "@mui/material/Select";
-import { clusterNames } from "../common/Constants";
+import { clusterNames, clusterNamesUserCreate } from "../common/Constants";
 import TitleTypography from "../common/TitleTypography";
 import FormHelperText from "@mui/material/FormHelperText";
 import RequiredField from "../common/RequiredField";
 import Typography from "@mui/material/Typography";
+import AdminContext from "../../context/admin";
 
 export default function ClusterInput({ formik, isDisabled }) {
+
+  const isAdmin = useContext(AdminContext);
+  const clusterNamesInput = isAdmin.admin ? clusterNames : clusterNamesUserCreate;
+
+console.log(isAdmin.admin)
   return (
     <Box
       sx={{
@@ -52,7 +58,7 @@ export default function ClusterInput({ formik, isDisabled }) {
           labelId="select-cluster"
           label="Cluster"
         >
-          {clusterNames.map((clusterOption) => (
+          {clusterNamesInput.map((clusterOption) => (
             <MenuItem key={clusterOption.id} value={clusterOption.name}>
               {clusterOption.humanFriendlyName}
             </MenuItem>


### PR DESCRIPTION
clusters CLAB, KLAB or KLAB2 are removed from users create product menu
![FireShot Capture 126 - Product Registry - localhost](https://user-images.githubusercontent.com/65827870/228074809-174e16ba-1fd2-4679-b120-d689c8f57ede.png)

![FireShot Capture 125 - Product Registry - localhost](https://user-images.githubusercontent.com/65827870/228074859-e87fda9b-e9d3-4edd-bfbd-db4147024b42.png)
