### PR TITLE
Fixed no products page for public cloud

### DIFF
--- a/src/pages/projects/publicCloud/AdminProjects.js
+++ b/src/pages/projects/publicCloud/AdminProjects.js
@@ -157,7 +157,7 @@ export default function Projects() {
       ) : (
         <EmptyList
           title="There are no products to be displayed"
-          subtitle="You currently have no products hosted on the Private Cloud OpenShift platform."
+          subtitle="You currently have no Public Cloud products."
           isPrivate={false}
           isPublic={true}
         />

--- a/src/pages/projects/publicCloud/UserProjects.js
+++ b/src/pages/projects/publicCloud/UserProjects.js
@@ -177,7 +177,7 @@ export default function Projects() {
       ) : (
         <EmptyList
           title="There are no products to be displayed"
-          subtitle="You currently have no products hosted on the Private Cloud OpenShift platform."
+          subtitle="You currently have no Public Cloud products."
           isPrivate={false}
           isPublic={true}
         />


### PR DESCRIPTION
Currently, the no products page for public cloud mentions private cloud. I have fixed that.